### PR TITLE
feat: add reusable PageHeader component with title, description, and …

### DIFF
--- a/src/app/placeholder/page.tsx
+++ b/src/app/placeholder/page.tsx
@@ -1,0 +1,24 @@
+import { PageHeader } from "@/components/ui/PageHeader";
+
+import React from "react";
+
+const PlaceHolderPage = () => {
+  return (
+    <PageHeader
+      title={"Page Header"}
+      description={
+        "This is a placeholder description to test the style of this component: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam quis nibh sollicitudin libero porta interdum ac vel urna. Quisque a ipsum leo. Curabitur tristique ut erat sed ultrices. Nulla laoreet porttitor aliquam. Donec ut sodales nisl, at volutpat nisl. Maecenas tortor mi, hendrerit quis eros at, porttitor scelerisque eros. Suspendisse ligula nisi, pretium quis vestibulum vel, iaculis sit amet nisl. Integer id nibh dolor. Vivamus ut fermentum tellus, in mollis nisl. In quis venenatis ante, a tempor dui. Integer dapibus arcu quis mauris varius, dignissim pharetra arcu auctor. Maecenas id imperdiet odio. In sit amet efficitur arcu. Suspendisse potenti. Nam in diam dui. "
+      }
+    >
+      <button className="bg-[#6c47ff] text-white rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 cursor-pointer">
+        Action button
+      </button>
+
+      <button className="bg-[#6c47ff] text-white rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 cursor-pointer">
+        Action button
+      </button>
+    </PageHeader>
+  );
+};
+
+export default PlaceHolderPage;

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -1,0 +1,21 @@
+import { FC } from "react";
+
+interface Props {
+  title: string;
+  description?: string;
+  children?: React.ReactNode;
+}
+
+export const PageHeader: FC<Props> = ({ title, description, children }) => {
+  return (
+    <header className="mb-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
+        <div className="flex space-x-4">{children}</div>
+      </div>
+      {description && (
+        <p className="text-gray-500 mt-4 max-w-full">{description}</p>
+      )}
+    </header>
+  );
+};


### PR DESCRIPTION
…action buttons as children prop (#4)

This PR implements the PageHeader component as described in issue #4.
Includes support for title, optional description, and action buttons.

Acceptance Criteria:
- [x] Create a new component at /components/ui/page-header.tsx.
- [x] The component should accept props: title (string), description (string, optional).
- [x] The component should also accept children to render action buttons on the right side.
- [x] Use h1 for the title and a muted paragraph for the description, styled with Tailwind CSS.
- [x] Implement the component on a placeholder page to demonstrate its usage.